### PR TITLE
NET-34: handle 401 errors at frontend

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -4,11 +4,12 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './interceptors/auth-interceptor';
+import { httpErrorInterceptor } from './interceptors/http-error-interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([authInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, httpErrorInterceptor])),
   ],
 };

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -16,7 +16,6 @@ export class App {
   public readonly currentYear = new Date().getFullYear();
 
   public logout() {
-    localStorage.removeItem('token');
     this.authService.logout().subscribe({
       next: () => this.router.navigateByUrl('/login'),
     });

--- a/frontend/src/app/components/login/login.ts
+++ b/frontend/src/app/components/login/login.ts
@@ -50,10 +50,7 @@ export class Login implements OnInit {
 
     this.authService.login(request).subscribe({
       next: () => this.router.navigateByUrl('/profile'),
-      error: (err) => {
-        this.errorMessage.set(err.error.detail || 'An error occurred during login.');
-        console.log(err.error);
-      },
+      error: (err) => this.errorMessage.set(err.error.detail || 'An error occurred during login.'),
     });
   }
 

--- a/frontend/src/app/interceptors/auth-interceptor.ts
+++ b/frontend/src/app/interceptors/auth-interceptor.ts
@@ -1,9 +1,10 @@
 import { HttpInterceptorFn } from '@angular/common/http';
-
-const LS_TOKEN_KEY = 'token';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth-service';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
-  const token = localStorage.getItem(LS_TOKEN_KEY);
+  const authService = inject(AuthService);
+  const token = authService.accessToken;
   if (!token) {
     return next(req);
   }

--- a/frontend/src/app/interceptors/http-error-interceptor.ts
+++ b/frontend/src/app/interceptors/http-error-interceptor.ts
@@ -1,0 +1,44 @@
+import { HttpErrorResponse, HttpEvent, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
+import { catchError, Observable, switchMap, throwError } from 'rxjs';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth-service';
+
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        return handle401(authService, req, error, next);
+      }
+      return throwError(() => error);
+    }),
+  );
+};
+
+function handle401(
+  authService: AuthService,
+  req: HttpRequest<unknown>,
+  error: HttpErrorResponse,
+  next: (req: HttpRequest<unknown>) => Observable<HttpEvent<unknown>>,
+) {
+  if (req.url.includes('/auth/refresh')) {
+    authService.handleUnauthorized();
+    return throwError(() => error);
+  }
+
+  return authService.refresh().pipe(
+    switchMap((_) => {
+      const token = authService.accessToken;
+      const cloned = req.clone({
+        setHeaders: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return next(cloned);
+    }),
+    catchError((refreshError) => {
+      authService.handleUnauthorized();
+      return throwError(() => refreshError);
+    }),
+  );
+}

--- a/frontend/src/app/services/auth-service.ts
+++ b/frontend/src/app/services/auth-service.ts
@@ -3,42 +3,69 @@ import { environment } from '../../environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { LoginRequest } from '../models/auth/login-request';
 import { LoginResponse } from '../models/auth/login-response';
-import { finalize, Observable, tap } from 'rxjs';
+import { finalize, Observable, shareReplay, tap } from 'rxjs';
 import { RegisterRequest } from '../models/auth/register-request';
 import { BasicUser } from '../models/user/user-response';
+import { Router } from '@angular/router';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   private readonly jwtTokenKey = 'token';
-  private readonly apiUrl = environment.apiUrl;
+  private readonly authUrl = `${environment.apiUrl}/auth`;
   private readonly httpClient = inject(HttpClient);
+  private readonly router = inject(Router);
+
+  private refreshTokenRequest$: Observable<LoginResponse> | null = null;
 
   public register(body: RegisterRequest): Observable<BasicUser> {
-    return this.httpClient.post<BasicUser>(`${this.apiUrl}/auth/register`, body);
+    return this.httpClient.post<BasicUser>(`${this.authUrl}/register`, body);
   }
 
   public login(body: LoginRequest): Observable<LoginResponse> {
     return this.httpClient
-      .post<LoginResponse>(`${this.apiUrl}/auth/login`, body, { withCredentials: true })
-      .pipe(tap((res) => localStorage.setItem(this.jwtTokenKey, res.token)));
+      .post<LoginResponse>(`${this.authUrl}/login`, body, { withCredentials: true })
+      .pipe(tap((res) => this.saveAccessToken(res.token)));
   }
 
   public refresh(): Observable<LoginResponse> {
-    return this.httpClient
-      .post<LoginResponse>(`${this.apiUrl}/auth/refresh`, {}, { withCredentials: true })
-      .pipe(tap((res) => localStorage.setItem(this.jwtTokenKey, res.token)));
+    if (!this.refreshTokenRequest$) {
+      this.refreshTokenRequest$ = this.httpClient
+        .post<LoginResponse>(`${this.authUrl}/refresh`, {}, { withCredentials: true })
+        .pipe(
+          tap((res) => this.saveAccessToken(res.token)),
+          finalize(() => (this.refreshTokenRequest$ = null)),
+          shareReplay(1),
+        );
+    }
+    return this.refreshTokenRequest$;
   }
 
   public logout(): Observable<void> {
     return this.httpClient
-      .post<void>(`${this.apiUrl}/auth/logout`, {}, { withCredentials: true })
-      .pipe(finalize(() => localStorage.removeItem(this.jwtTokenKey)));
+      .post<void>(`${this.authUrl}/logout`, {}, { withCredentials: true })
+      .pipe(finalize(() => this.clearAccessToken()));
   }
 
   public isAuthenticated(): boolean {
-    const token = localStorage.getItem(this.jwtTokenKey);
-    return !!token;
+    return !!this.accessToken;
+  }
+
+  public handleUnauthorized(): void {
+    this.clearAccessToken();
+    this.router.navigate(['/login']);
+  }
+
+  public get accessToken(): string | null {
+    return localStorage.getItem(this.jwtTokenKey);
+  }
+
+  private saveAccessToken(token: string): void {
+    localStorage.setItem(this.jwtTokenKey, token);
+  }
+
+  private clearAccessToken(): void {
+    localStorage.removeItem(this.jwtTokenKey);
   }
 }


### PR DESCRIPTION
## Summary

This PR handles unauthorized errors gloablly at the frontend side.

After client gets 401 status code, then there is a refresh attempt. After failure of refresh client is redirected to the login page with cleared context (access and refresh token for example).