### PR TITLE
NET-45: add monitoring tasks type-specific configurations

### DIFF
--- a/frontend/src/app/components/console/tasks/create-task/create-task.html
+++ b/frontend/src/app/components/console/tasks/create-task/create-task.html
@@ -29,6 +29,108 @@
         <small class="error-message">An interval between 1s and 1m must be provided.</small>
       }
     </div>
+    <div class="subform" formGroupName="configuration">
+      @switch (taskCreateForm.controls.type.value) {
+        @case (TaskType.PING) {
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+
+        @case (TaskType.TELNET) {
+          <div class="form-group">
+            <label for="port">Port</label>
+            <input id="port" type="number" min="1" max="65535" formControlName="port" />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.port.invalid &&
+              taskCreateForm.controls.configuration.controls.port.touched
+            ) {
+              <small class="error-message">Port must be between 1 and 65535.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+
+        @case (TaskType.HTTP_HEALTHCHECK) {
+          <div class="form-group">
+            <label for="path">Path</label>
+            <input id="path" type="text" formControlName="path" placeholder="/health" />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.path.invalid &&
+              taskCreateForm.controls.configuration.controls.path.touched
+            ) {
+              <small class="error-message">Path is required.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="port">Port</label>
+            <input id="port" type="number" min="1" max="65535" formControlName="port" />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.port.invalid &&
+              taskCreateForm.controls.configuration.controls.port.touched
+            ) {
+              <small class="error-message">Port must be between 1 and 65535.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskCreateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+      }
+    </div>
     <div class="form-actions">
       <button type="reset">Clear</button>
       <button type="submit">Create</button>

--- a/frontend/src/app/components/console/tasks/create-task/create-task.ts
+++ b/frontend/src/app/components/console/tasks/create-task/create-task.ts
@@ -21,9 +21,15 @@ export class CreateTask {
   protected readonly TASK_TYPE_LABELS = TASK_TYPE_LABELS;
 
   protected readonly errorMessage = signal('');
+
   protected readonly taskCreateForm = this.fb.nonNullable.group({
     intervalSeconds: [5, [Validators.required, Validators.min(1)]],
     type: [TaskType.PING, Validators.required],
+    configuration: this.fb.nonNullable.group({
+      port: [23, [Validators.required, Validators.min(1), Validators.max(65535)]],
+      path: ['/health', Validators.required],
+      timeoutMs: [2000, [Validators.required, Validators.min(1)]],
+    }),
   });
 
   protected submit(): void {
@@ -32,7 +38,16 @@ export class CreateTask {
       return;
     }
 
-    const request: MonitoringTaskCreateRequest = this.taskCreateForm.getRawValue();
+    const value = this.taskCreateForm.getRawValue();
+
+    const request: MonitoringTaskCreateRequest = {
+      type: value.type,
+      intervalSeconds: value.intervalSeconds,
+      configuration: {
+        type: value.type,
+        ...value.configuration,
+      },
+    };
 
     this.tasksService.createTask(this.data.deviceId, request).subscribe({
       next: () => this.dialogRef.close({ created: true }),

--- a/frontend/src/app/components/console/tasks/create-task/create-task.ts
+++ b/frontend/src/app/components/console/tasks/create-task/create-task.ts
@@ -18,6 +18,7 @@ export class CreateTask {
   private readonly data = inject<{ deviceId: number }>(DIALOG_DATA);
 
   protected readonly taskTypes = Object.values(TaskType);
+  protected readonly TaskType = TaskType;
   protected readonly TASK_TYPE_LABELS = TASK_TYPE_LABELS;
 
   protected readonly errorMessage = signal('');
@@ -28,7 +29,7 @@ export class CreateTask {
     configuration: this.fb.nonNullable.group({
       port: [23, [Validators.required, Validators.min(1), Validators.max(65535)]],
       path: ['/health', Validators.required],
-      timeoutMs: [2000, [Validators.required, Validators.min(1)]],
+      timeoutSeconds: [2.0, [Validators.required, Validators.min(0.5), Validators.max(5)]],
     }),
   });
 
@@ -40,13 +41,37 @@ export class CreateTask {
 
     const value = this.taskCreateForm.getRawValue();
 
+    let configuration;
+    switch (value.type) {
+      case TaskType.PING:
+        configuration = {
+          type: value.type,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+
+      case TaskType.TELNET:
+        configuration = {
+          type: value.type,
+          port: value.configuration.port,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+
+      case TaskType.HTTP_HEALTHCHECK:
+        configuration = {
+          type: value.type,
+          port: value.configuration.port,
+          path: value.configuration.path,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+    }
+
     const request: MonitoringTaskCreateRequest = {
       type: value.type,
       intervalSeconds: value.intervalSeconds,
-      configuration: {
-        type: value.type,
-        ...value.configuration,
-      },
+      configuration
     };
 
     this.tasksService.createTask(this.data.deviceId, request).subscribe({

--- a/frontend/src/app/components/console/tasks/create-task/create-task.ts
+++ b/frontend/src/app/components/console/tasks/create-task/create-task.ts
@@ -71,7 +71,7 @@ export class CreateTask {
     const request: MonitoringTaskCreateRequest = {
       type: value.type,
       intervalSeconds: value.intervalSeconds,
-      configuration
+      configuration,
     };
 
     this.tasksService.createTask(this.data.deviceId, request).subscribe({

--- a/frontend/src/app/components/console/tasks/tasks.html
+++ b/frontend/src/app/components/console/tasks/tasks.html
@@ -53,6 +53,50 @@
                 <span>{{ task.interval.replace('PT', '') }}</span>
               </div>
 
+              <div class="task-configuration">
+                <div class="configuration-header">
+                  <span class="detail-label">Configuration</span>
+                </div>
+
+                @switch (task.type) {
+                  @case (TaskType.PING) {
+                    <div class="detail-row">
+                      <span class="detail-label">Timeout</span>
+                      <span>{{ task.configuration.timeout }}</span>
+                    </div>
+                  }
+
+                  @case (TaskType.TELNET) {
+                    <div class="detail-row">
+                      <span class="detail-label">Port</span>
+                      <span>{{ task.configuration.port }}</span>
+                    </div>
+
+                    <div class="detail-row">
+                      <span class="detail-label">Timeout</span>
+                      <span>{{ task.configuration.timeout }}</span>
+                    </div>
+                  }
+
+                  @case (TaskType.HTTP_HEALTHCHECK) {
+                    <div class="detail-row">
+                      <span class="detail-label">Port</span>
+                      <span>{{ task.configuration.port }}</span>
+                    </div>
+
+                    <div class="detail-row">
+                      <span class="detail-label">Path</span>
+                      <span>{{ task.configuration.path }}</span>
+                    </div>
+
+                    <div class="detail-row">
+                      <span class="detail-label">Timeout</span>
+                      <span>{{ task.configuration.timeout }}</span>
+                    </div>
+                  }
+                }
+              </div>
+
               <div class="detail-row">
                 <span class="detail-label">Created</span>
                 <span>{{ task.createdAt | date: 'yyyy-MM-dd HH:mm' }}</span>

--- a/frontend/src/app/components/console/tasks/tasks.html
+++ b/frontend/src/app/components/console/tasks/tasks.html
@@ -52,50 +52,43 @@
                 <span class="detail-label">Interval</span>
                 <span>{{ task.interval.replace('PT', '') }}</span>
               </div>
-
-              <div class="task-configuration">
-                <div class="configuration-header">
-                  <span class="detail-label">Configuration</span>
-                </div>
-
-                @switch (task.type) {
-                  @case (TaskType.PING) {
-                    <div class="detail-row">
-                      <span class="detail-label">Timeout</span>
-                      <span>{{ task.configuration.timeout }}</span>
-                    </div>
-                  }
-
-                  @case (TaskType.TELNET) {
-                    <div class="detail-row">
-                      <span class="detail-label">Port</span>
-                      <span>{{ task.configuration.port }}</span>
-                    </div>
-
-                    <div class="detail-row">
-                      <span class="detail-label">Timeout</span>
-                      <span>{{ task.configuration.timeout }}</span>
-                    </div>
-                  }
-
-                  @case (TaskType.HTTP_HEALTHCHECK) {
-                    <div class="detail-row">
-                      <span class="detail-label">Port</span>
-                      <span>{{ task.configuration.port }}</span>
-                    </div>
-
-                    <div class="detail-row">
-                      <span class="detail-label">Path</span>
-                      <span>{{ task.configuration.path }}</span>
-                    </div>
-
-                    <div class="detail-row">
-                      <span class="detail-label">Timeout</span>
-                      <span>{{ task.configuration.timeout }}</span>
-                    </div>
-                  }
+              @switch (task.type) {
+                @case (TaskType.PING) {
+                  <div class="detail-row">
+                    <span class="detail-label">Timeout</span>
+                    <span>{{ task.configuration.timeout.replace('PT', '') }}</span>
+                  </div>
                 }
-              </div>
+
+                @case (TaskType.TELNET) {
+                  <div class="detail-row">
+                    <span class="detail-label">Port</span>
+                    <span>{{ task.configuration.port }}</span>
+                  </div>
+
+                  <div class="detail-row">
+                    <span class="detail-label">Timeout</span>
+                    <span>{{ task.configuration.timeout.replace('PT', '') }}</span>
+                  </div>
+                }
+
+                @case (TaskType.HTTP_HEALTHCHECK) {
+                  <div class="detail-row">
+                    <span class="detail-label">Port</span>
+                    <span>{{ task.configuration.port }}</span>
+                  </div>
+
+                  <div class="detail-row">
+                    <span class="detail-label">Path</span>
+                    <span>{{ task.configuration.path }}</span>
+                  </div>
+
+                  <div class="detail-row">
+                    <span class="detail-label">Timeout</span>
+                    <span>{{ task.configuration.timeout.replace('PT', '') }}</span>
+                  </div>
+                }
+              }
 
               <div class="detail-row">
                 <span class="detail-label">Created</span>

--- a/frontend/src/app/components/console/tasks/tasks.scss
+++ b/frontend/src/app/components/console/tasks/tasks.scss
@@ -1,0 +1,15 @@
+.task-configuration {
+  margin: 1rem 0;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+
+  .configuration-header {
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+  }
+
+  .detail-row {
+    margin: 0.25rem 0;
+  }
+}

--- a/frontend/src/app/components/console/tasks/tasks.ts
+++ b/frontend/src/app/components/console/tasks/tasks.ts
@@ -6,9 +6,14 @@ import { switchMap } from 'rxjs';
 import { CreateTask } from './create-task/create-task';
 import { Dialog } from '@angular/cdk/dialog';
 import { DatePipe } from '@angular/common';
-import { TASK_TYPE_LABELS } from '../../../models/tasks/task-type';
+import { TASK_TYPE_LABELS, TaskType } from '../../../models/tasks/task-type';
 import { UpdateTask } from './update-task/update-task';
-import { MonitoringTaskResponse } from '../../../models/tasks/monitoring-task-response';
+import {
+  HttpHealthcheckMonitoringTaskResponse,
+  MonitoringTaskResponse,
+  PingMonitoringTaskResponse,
+  TelnetMonitoringTaskResponse,
+} from '../../../models/tasks/monitoring-task-response';
 import { ConfirmDialog } from '../../shared/confirm-dialog/confirm-dialog';
 
 @Component({
@@ -23,6 +28,7 @@ export class Tasks {
   private readonly dialog = inject(Dialog);
 
   protected readonly TASK_TYPE_LABELS = TASK_TYPE_LABELS;
+  protected readonly TaskType = TaskType;
 
   private readonly reload = signal(0);
   protected readonly message = signal('');
@@ -56,7 +62,12 @@ export class Tasks {
     });
   }
 
-  protected openEditDialog(task: MonitoringTaskResponse) {
+  protected openEditDialog(
+    task:
+      | PingMonitoringTaskResponse
+      | TelnetMonitoringTaskResponse
+      | HttpHealthcheckMonitoringTaskResponse,
+  ) {
     const dialogRef = this.dialog.open(UpdateTask, {
       data: {
         deviceId: this.selectedDeviceId(),

--- a/frontend/src/app/components/console/tasks/update-task/update-task.html
+++ b/frontend/src/app/components/console/tasks/update-task/update-task.html
@@ -23,6 +23,108 @@
         <small class="error-message">An interval between 1s and 1m must be provided.</small>
       }
     </div>
+    <div class="subform" formGroupName="configuration">
+      @switch (data.task.type) {
+        @case (TaskType.PING) {
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+
+        @case (TaskType.TELNET) {
+          <div class="form-group">
+            <label for="port">Port</label>
+            <input id="port" type="number" min="1" max="65535" formControlName="port" />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.port.invalid &&
+              taskUpdateForm.controls.configuration.controls.port.touched
+            ) {
+              <small class="error-message">Port must be between 1 and 65535.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+
+        @case (TaskType.HTTP_HEALTHCHECK) {
+          <div class="form-group">
+            <label for="path">Path</label>
+            <input id="path" type="text" formControlName="path" placeholder="/health" />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.path.invalid &&
+              taskUpdateForm.controls.configuration.controls.path.touched
+            ) {
+              <small class="error-message">Path is required.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="port">Port</label>
+            <input id="port" type="number" min="1" max="65535" formControlName="port" />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.port.invalid &&
+              taskUpdateForm.controls.configuration.controls.port.touched
+            ) {
+              <small class="error-message">Port must be between 1 and 65535.</small>
+            }
+          </div>
+
+          <div class="form-group">
+            <label for="timeoutSeconds">Enter acceptable timeout (seconds)</label>
+            <input
+              id="timeoutSeconds"
+              type="number"
+              min="0.5"
+              max="5"
+              step="0.5"
+              formControlName="timeoutSeconds"
+            />
+
+            @if (
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.invalid &&
+              taskUpdateForm.controls.configuration.controls.timeoutSeconds.touched
+            ) {
+              <small class="error-message">A timeout between 0.5s and 5s must be provided.</small>
+            }
+          </div>
+        }
+      }
+    </div>
     <div class="form-actions">
       <button type="reset">Clear</button>
       <button type="submit">Update</button>

--- a/frontend/src/app/components/console/tasks/update-task/update-task.ts
+++ b/frontend/src/app/components/console/tasks/update-task/update-task.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { TASK_TYPE_LABELS } from '../../../../models/tasks/task-type';
+import { TASK_TYPE_LABELS, TaskType } from '../../../../models/tasks/task-type';
 import { MonitoringTasksService } from '../../../../services/monitoring-tasks-service';
 import { MonitoringTaskUpdateRequest } from '../../../../models/tasks/monitoring-task-request';
 import {
@@ -30,6 +30,8 @@ export class UpdateTask {
   private readonly taskServices = inject(MonitoringTasksService);
 
   protected readonly data = inject<UpdateTaskDialogData>(DIALOG_DATA);
+
+  protected readonly TaskType = TaskType;
   protected readonly TASK_TYPE_LABELS = TASK_TYPE_LABELS;
 
   protected readonly errorMessage = signal('');
@@ -41,7 +43,7 @@ export class UpdateTask {
     configuration: this.fb.nonNullable.group({
       port: [23, [Validators.required, Validators.min(1), Validators.max(65535)]],
       path: ['/health', Validators.required],
-      timeoutMs: [2000, [Validators.required, Validators.min(1)]],
+      timeoutSeconds: [2.0, [Validators.required, Validators.min(0.5), Validators.max(5)]],
     }),
   });
 
@@ -53,12 +55,36 @@ export class UpdateTask {
 
     const value = this.taskUpdateForm.getRawValue();
 
+    let configuration;
+    switch (this.data.task.type) {
+      case TaskType.PING:
+        configuration = {
+          type: this.data.task.type,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+
+      case TaskType.TELNET:
+        configuration = {
+          type: this.data.task.type,
+          port: value.configuration.port,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+
+      case TaskType.HTTP_HEALTHCHECK:
+        configuration = {
+          type: this.data.task.type,
+          port: value.configuration.port,
+          path: value.configuration.path,
+          timeoutMs: value.configuration.timeoutSeconds * 1000,
+        };
+        break;
+    }
+
     const request: MonitoringTaskUpdateRequest = {
       intervalSeconds: value.intervalSeconds,
-      configuration: {
-        type: this.data.task.type,
-        ...value.configuration,
-      },
+      configuration,
     };
 
     this.taskServices.updateTask(this.data.deviceId, request, this.data.task.id).subscribe({

--- a/frontend/src/app/components/console/tasks/update-task/update-task.ts
+++ b/frontend/src/app/components/console/tasks/update-task/update-task.ts
@@ -4,11 +4,18 @@ import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { TASK_TYPE_LABELS } from '../../../../models/tasks/task-type';
 import { MonitoringTasksService } from '../../../../services/monitoring-tasks-service';
 import { MonitoringTaskUpdateRequest } from '../../../../models/tasks/monitoring-task-request';
-import { MonitoringTaskResponse } from '../../../../models/tasks/monitoring-task-response';
+import {
+  HttpHealthcheckMonitoringTaskResponse,
+  PingMonitoringTaskResponse,
+  TelnetMonitoringTaskResponse,
+} from '../../../../models/tasks/monitoring-task-response';
 
 interface UpdateTaskDialogData {
   deviceId: number;
-  task: MonitoringTaskResponse;
+  task:
+    | PingMonitoringTaskResponse
+    | TelnetMonitoringTaskResponse
+    | HttpHealthcheckMonitoringTaskResponse;
 }
 
 @Component({
@@ -31,6 +38,11 @@ export class UpdateTask {
       this.intervalToSeconds(this.data.task.interval),
       [Validators.required, Validators.min(1)],
     ],
+    configuration: this.fb.nonNullable.group({
+      port: [23, [Validators.required, Validators.min(1), Validators.max(65535)]],
+      path: ['/health', Validators.required],
+      timeoutMs: [2000, [Validators.required, Validators.min(1)]],
+    }),
   });
 
   protected submit(): void {
@@ -39,7 +51,15 @@ export class UpdateTask {
       return;
     }
 
-    const request: MonitoringTaskUpdateRequest = this.taskUpdateForm.getRawValue();
+    const value = this.taskUpdateForm.getRawValue();
+
+    const request: MonitoringTaskUpdateRequest = {
+      intervalSeconds: value.intervalSeconds,
+      configuration: {
+        type: this.data.task.type,
+        ...value.configuration,
+      },
+    };
 
     this.taskServices.updateTask(this.data.deviceId, request, this.data.task.id).subscribe({
       next: () => this.dialogRef.close({ updated: true }),

--- a/frontend/src/app/components/console/tasks/update-task/update-task.ts
+++ b/frontend/src/app/components/console/tasks/update-task/update-task.ts
@@ -41,9 +41,15 @@ export class UpdateTask {
       [Validators.required, Validators.min(1)],
     ],
     configuration: this.fb.nonNullable.group({
-      port: [23, [Validators.required, Validators.min(1), Validators.max(65535)]],
-      path: ['/health', Validators.required],
-      timeoutSeconds: [2.0, [Validators.required, Validators.min(0.5), Validators.max(5)]],
+      port: [
+        this.getConfigurationDefaults().port,
+        [Validators.required, Validators.min(1), Validators.max(65535)],
+      ],
+      path: [this.getConfigurationDefaults().path, Validators.required],
+      timeoutSeconds: [
+        this.getConfigurationDefaults().timeoutSeconds,
+        [Validators.required, Validators.min(0.5), Validators.max(5)],
+      ],
     }),
   });
 
@@ -95,11 +101,38 @@ export class UpdateTask {
   }
 
   private intervalToSeconds(interval: string): number {
-    const match = interval.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+    const match = interval.match(
+      /^PT(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/,
+    );
     if (!match) return 5;
     const hours = Number(match[1] ?? 0);
     const minutes = Number(match[2] ?? 0);
     const seconds = Number(match[3] ?? 0);
     return hours * 3600 + minutes * 60 + seconds;
+  }
+
+  private getConfigurationDefaults() {
+    switch (this.data.task.type) {
+      case TaskType.PING:
+        return {
+          port: 23,
+          path: '/health',
+          timeoutSeconds: this.intervalToSeconds(this.data.task.configuration.timeout),
+        };
+
+      case TaskType.TELNET:
+        return {
+          port: this.data.task.configuration.port,
+          path: '/health',
+          timeoutSeconds: this.intervalToSeconds(this.data.task.configuration.timeout),
+        };
+
+      case TaskType.HTTP_HEALTHCHECK:
+        return {
+          port: this.data.task.configuration.port,
+          path: this.data.task.configuration.path,
+          timeoutSeconds: this.intervalToSeconds(this.data.task.configuration.timeout),
+        };
+    }
   }
 }

--- a/frontend/src/app/models/tasks/monitoring-task-configuration-request.ts
+++ b/frontend/src/app/models/tasks/monitoring-task-configuration-request.ts
@@ -1,0 +1,24 @@
+import { TaskType } from './task-type';
+
+export interface PingTaskConfigurationRequest {
+  type: TaskType.PING;
+  timeoutMs: number;
+}
+
+export interface TelnetTaskConfigurationRequest {
+  type: TaskType.TELNET;
+  port: number;
+  timeoutMs: number;
+}
+
+export interface HttpHealthcheckTaskConfigurationRequest {
+  type: TaskType.HTTP_HEALTHCHECK;
+  port: number;
+  path: string;
+  timeoutMs: number;
+}
+
+export type MonitoringTaskConfigurationRequest =
+  | PingTaskConfigurationRequest
+  | TelnetTaskConfigurationRequest
+  | HttpHealthcheckTaskConfigurationRequest;

--- a/frontend/src/app/models/tasks/monitoring-task-configuration-response.ts
+++ b/frontend/src/app/models/tasks/monitoring-task-configuration-response.ts
@@ -1,0 +1,19 @@
+export interface PingTaskConfigurationResponse {
+  timeout: string;
+}
+
+export interface TelnetTaskConfigurationResponse {
+  timeout: string;
+  port: number;
+}
+
+export interface HttpHealthcheckTaskConfigurationResponse {
+  timeout: string;
+  port: number;
+  path: string;
+}
+
+export type MonitoringTaskConfigurationResponse =
+  | PingTaskConfigurationResponse
+  | TelnetTaskConfigurationResponse
+  | HttpHealthcheckTaskConfigurationResponse;

--- a/frontend/src/app/models/tasks/monitoring-task-request.ts
+++ b/frontend/src/app/models/tasks/monitoring-task-request.ts
@@ -1,10 +1,13 @@
 import { TaskType } from './task-type';
+import { MonitoringTaskConfigurationRequest } from './monitoring-task-configuration-request';
 
 export interface MonitoringTaskCreateRequest {
   type: TaskType;
   intervalSeconds: number;
+  configuration: MonitoringTaskConfigurationRequest;
 }
 
 export interface MonitoringTaskUpdateRequest {
   intervalSeconds: number;
+  configuration: MonitoringTaskConfigurationRequest;
 }

--- a/frontend/src/app/models/tasks/monitoring-task-response.ts
+++ b/frontend/src/app/models/tasks/monitoring-task-response.ts
@@ -1,10 +1,29 @@
 import { TaskType } from './task-type';
+import {
+  HttpHealthcheckTaskConfigurationResponse,
+  PingTaskConfigurationResponse,
+  TelnetTaskConfigurationResponse,
+} from './monitoring-task-configuration-response';
 
 export interface MonitoringTaskResponse {
   id: number;
-  type: TaskType;
   interval: string;
   isEnabled: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface PingMonitoringTaskResponse extends MonitoringTaskResponse {
+  type: TaskType.PING;
+  configuration: PingTaskConfigurationResponse;
+}
+
+export interface TelnetMonitoringTaskResponse extends MonitoringTaskResponse {
+  type: TaskType.TELNET;
+  configuration: TelnetTaskConfigurationResponse;
+}
+
+export interface HttpHealthcheckMonitoringTaskResponse extends MonitoringTaskResponse {
+  type: TaskType.HTTP_HEALTHCHECK;
+  configuration: HttpHealthcheckTaskConfigurationResponse;
 }

--- a/frontend/src/app/services/monitoring-tasks-service.ts
+++ b/frontend/src/app/services/monitoring-tasks-service.ts
@@ -3,7 +3,12 @@ import { NetworkContextService } from './network-context-service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
-import { MonitoringTaskResponse } from '../models/tasks/monitoring-task-response';
+import {
+  HttpHealthcheckMonitoringTaskResponse,
+  MonitoringTaskResponse,
+  PingMonitoringTaskResponse,
+  TelnetMonitoringTaskResponse,
+} from '../models/tasks/monitoring-task-response';
 import {
   MonitoringTaskCreateRequest,
   MonitoringTaskUpdateRequest,
@@ -21,8 +26,14 @@ export class MonitoringTasksService {
     return `${environment.apiUrl}/networks/${networkId}/devices`;
   }
 
-  public getTasks(deviceId: number): Observable<MonitoringTaskResponse[]> {
-    return this.httpClient.get<MonitoringTaskResponse[]>(`${this.devicesUrl}/${deviceId}/tasks`);
+  public getTasks(deviceId: number) {
+    return this.httpClient.get<
+      (
+        | PingMonitoringTaskResponse
+        | TelnetMonitoringTaskResponse
+        | HttpHealthcheckMonitoringTaskResponse
+      )[]
+    >(`${this.devicesUrl}/${deviceId}/tasks`);
   }
 
   public createTask(

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -140,12 +140,20 @@ a.danger:hover {
   }
 }
 
-.form {
+.form,
+.subform {
   display: flex;
   flex-direction: column;
   gap: 15px;
+}
+
+.form {
   width: 300px;
   padding: 25px;
+}
+
+.subform {
+  width: 100%;
 }
 
 .form-group {

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/exception/domain/monitoring_task/MonitoringTaskValidationFailedException.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/exception/domain/monitoring_task/MonitoringTaskValidationFailedException.java
@@ -1,0 +1,9 @@
+package pl.sgorski.nethelt.webapi.exception.domain.monitoring_task;
+
+import pl.sgorski.nethelt.webapi.exception.application.ValidationFailedException;
+
+public final class MonitoringTaskValidationFailedException extends ValidationFailedException {
+  public MonitoringTaskValidationFailedException(String cause) {
+    super("Monitoring task validation failed: " + cause);
+  }
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
@@ -36,8 +36,8 @@ public class MonitoringTask {
   @Column(nullable = false)
   private boolean isEnabled = true;
 
-  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-  @JoinColumn(name = "configuration_id")
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, optional = false)
+  @JoinColumn(name = "configuration_id", nullable = false, unique = true)
   private MonitoringTaskConfiguration configuration;
 
   @CreationTimestamp

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
@@ -13,7 +13,7 @@ import pl.sgorski.nethelt.webapi.features.device.domain.Device;
 @Entity
 @Getter
 @Table(name = "monitoring_tasks")
-@EqualsAndHashCode(exclude = "device")
+@EqualsAndHashCode(exclude = {"device", "configuration"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MonitoringTask {
 
@@ -36,6 +36,10 @@ public class MonitoringTask {
   @Column(nullable = false)
   private boolean isEnabled = true;
 
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "configuration_id")
+  private MonitoringTaskConfiguration configuration;
+
   @CreationTimestamp
   @Column(nullable = false)
   private Instant createdAt;
@@ -44,10 +48,12 @@ public class MonitoringTask {
   @Column(nullable = false)
   private Instant updatedAt;
 
-  public MonitoringTask(Device device, TaskType type, Duration interval) {
+  public MonitoringTask(
+      Device device, TaskType type, Duration interval, MonitoringTaskConfiguration configuration) {
     this.device = device;
     this.type = type;
     this.interval = interval;
+    this.configuration = configuration;
   }
 
   public void update(Duration interval) {

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTask.java
@@ -56,8 +56,9 @@ public class MonitoringTask {
     this.configuration = configuration;
   }
 
-  public void update(Duration interval) {
+  public void update(Duration interval, MonitoringTaskConfiguration configuration) {
     this.interval = interval;
+    this.configuration = configuration;
   }
 
   public void enable() {

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskConfiguration.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskConfiguration.java
@@ -1,0 +1,15 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "monitoring_task_configurations")
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class MonitoringTaskConfiguration {
+
+  @Id
+  @Getter
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfiguration.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfiguration.java
@@ -1,0 +1,44 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
+
+@Entity
+@Getter
+@Table(name = "http_healthcheck_task_configurations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HttpHealthcheckTaskConfiguration extends MonitoringTaskConfiguration {
+
+  @Column(nullable = false)
+  private int port;
+
+  @Column(nullable = false)
+  private String path;
+
+  @Getter
+  @Column(nullable = false)
+  @JdbcTypeCode(SqlTypes.INTERVAL_SECOND)
+  private Duration timeout;
+
+  public HttpHealthcheckTaskConfiguration(int port, String path, Duration timeout) {
+    if (port < 1 || port > 65535) {
+      throw new MonitoringTaskValidationFailedException("TCP/IP port must be between 1 and 65535");
+    }
+    if (path.isBlank() || !path.startsWith("/")) {
+      throw new MonitoringTaskValidationFailedException(
+          "HTTP path must be non-empty and start with '/'");
+    }
+    this.port = port;
+    this.path = path;
+    this.timeout = timeout;
+  }
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfiguration.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfiguration.java
@@ -33,7 +33,7 @@ public class HttpHealthcheckTaskConfiguration extends MonitoringTaskConfiguratio
     if (port < 1 || port > 65535) {
       throw new MonitoringTaskValidationFailedException("TCP/IP port must be between 1 and 65535");
     }
-    if (path.isBlank() || !path.startsWith("/")) {
+    if (!path.startsWith("/")) {
       throw new MonitoringTaskValidationFailedException(
           "HTTP path must be non-empty and start with '/'");
     }

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/PingTaskConfiguration.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/PingTaskConfiguration.java
@@ -1,0 +1,27 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
+
+@Entity
+@Table(name = "ping_task_configurations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PingTaskConfiguration extends MonitoringTaskConfiguration {
+
+  @Getter
+  @Column(nullable = false)
+  @JdbcTypeCode(SqlTypes.INTERVAL_SECOND)
+  private Duration timeout;
+
+  public PingTaskConfiguration(Duration timeout) {
+    this.timeout = timeout;
+  }
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/TelnetTaskConfiguration.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/TelnetTaskConfiguration.java
@@ -1,0 +1,34 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import jakarta.persistence.*;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
+
+@Entity
+@Table(name = "telnet_task_configurations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TelnetTaskConfiguration extends MonitoringTaskConfiguration {
+
+  @Getter
+  @Column(nullable = false)
+  private int port;
+
+  @Getter
+  @Column(nullable = false)
+  @JdbcTypeCode(SqlTypes.INTERVAL_SECOND)
+  private Duration timeout;
+
+  public TelnetTaskConfiguration(int port, Duration timeout) {
+    if (port < 1 || port > 65535) {
+      throw new MonitoringTaskValidationFailedException("TCP/IP port must be between 1 and 65535");
+    }
+    this.port = port;
+    this.timeout = timeout;
+  }
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/package-info.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskConfigurationCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskConfigurationCommand.java
@@ -1,0 +1,3 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command;
+
+public interface MonitoringTaskConfigurationCommand {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskCreateCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskCreateCommand.java
@@ -2,4 +2,5 @@ package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command;
 
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
 
-public record MonitoringTaskCreateCommand(TaskType type, long intervalSeconds) {}
+public record MonitoringTaskCreateCommand(
+    TaskType type, long intervalSeconds, MonitoringTaskConfigurationCommand configuration) {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskUpdateCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/MonitoringTaskUpdateCommand.java
@@ -1,3 +1,4 @@
 package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command;
 
-public record MonitoringTaskUpdateCommand(long intervalSeconds) {}
+public record MonitoringTaskUpdateCommand(
+    long intervalSeconds, MonitoringTaskConfigurationCommand configuration) {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/HttpHealthcheckTaskConfigurationCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/HttpHealthcheckTaskConfigurationCommand.java
@@ -1,0 +1,6 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration;
+
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
+
+public record HttpHealthcheckTaskConfigurationCommand(int port, String path, long timeoutMs)
+    implements MonitoringTaskConfigurationCommand {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/PingTaskConfigurationCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/PingTaskConfigurationCommand.java
@@ -1,0 +1,6 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration;
+
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
+
+public record PingTaskConfigurationCommand(long timeoutMs)
+    implements MonitoringTaskConfigurationCommand {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/TelnetTaskConfigurationCommand.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/TelnetTaskConfigurationCommand.java
@@ -1,0 +1,6 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration;
+
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
+
+public record TelnetTaskConfigurationCommand(int port, long timeoutMs)
+    implements MonitoringTaskConfigurationCommand {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/package-info.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/command/configuration/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskConfigurationRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskConfigurationRequest.java
@@ -1,0 +1,17 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.HttpHealthcheckTaskConfigurationRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.PingTaskConfigurationRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.TelnetTaskConfigurationRequest;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = PingTaskConfigurationRequest.class, name = "PING"),
+  @JsonSubTypes.Type(value = TelnetTaskConfigurationRequest.class, name = "TELNET"),
+  @JsonSubTypes.Type(
+      value = HttpHealthcheckTaskConfigurationRequest.class,
+      name = "HTTP_HEALTHCHECK")
+})
+public interface MonitoringTaskConfigurationRequest {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskCreateRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskCreateRequest.java
@@ -1,9 +1,12 @@
 package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
 
 public record MonitoringTaskCreateRequest(
     @NotNull(message = "Task type must be selected") TaskType type,
-    @Positive(message = "Task interval must be greater than 0 seconds") long intervalSeconds) {}
+    @Positive(message = "Task interval must be greater than 0 seconds") long intervalSeconds,
+    @NotNull(message = "Task must contain configuration") @Valid
+        MonitoringTaskConfigurationRequest configuration) {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskUpdateRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/MonitoringTaskUpdateRequest.java
@@ -1,6 +1,10 @@
 package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record MonitoringTaskUpdateRequest(
-    @Positive(message = "Task interval must be greater than 0 seconds") long intervalSeconds) {}
+    @Positive(message = "Task interval must be greater than 0 seconds") long intervalSeconds,
+    @NotNull(message = "Task must contain configuration") @Valid
+        MonitoringTaskConfigurationRequest configuration) {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/HttpHealthcheckTaskConfigurationRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/HttpHealthcheckTaskConfigurationRequest.java
@@ -1,0 +1,15 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskConfigurationRequest;
+
+public record HttpHealthcheckTaskConfigurationRequest(
+    @Min(value = 1, message = "Port must be greater than 0")
+        @Max(value = 65535, message = "Port must be max 65535.")
+        int port,
+    @NotBlank(message = "Path must be provided") String path,
+    @Positive(message = "Timeout must be provided in millis and positive.") long timeoutMs)
+    implements MonitoringTaskConfigurationRequest {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/PingTaskConfigurationRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/PingTaskConfigurationRequest.java
@@ -1,0 +1,8 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration;
+
+import jakarta.validation.constraints.Positive;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskConfigurationRequest;
+
+public record PingTaskConfigurationRequest(
+    @Positive(message = "Timeout must be provided in millis and positive.") long timeoutMs)
+    implements MonitoringTaskConfigurationRequest {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/TelnetTaskConfigurationRequest.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/TelnetTaskConfigurationRequest.java
@@ -1,0 +1,13 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskConfigurationRequest;
+
+public record TelnetTaskConfigurationRequest(
+    @Min(value = 1, message = "Port must be greater than 0")
+        @Max(value = 65535, message = "Port must be max 65535.")
+        int port,
+    @Positive(message = "Timeout must be provided in millis and positive.") long timeoutMs)
+    implements MonitoringTaskConfigurationRequest {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/package-info.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/request/configuration/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/MonitoringTaskConfigurationResponse.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/MonitoringTaskConfigurationResponse.java
@@ -1,0 +1,3 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response;
+
+public interface MonitoringTaskConfigurationResponse {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/MonitoringTaskResponse.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/MonitoringTaskResponse.java
@@ -9,5 +9,6 @@ public record MonitoringTaskResponse(
     TaskType type,
     Duration interval,
     boolean isEnabled,
+    MonitoringTaskConfigurationResponse configuration,
     Instant createdAt,
     Instant updatedAt) {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/HttpHealthcheckTaskConfigurationResponse.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/HttpHealthcheckTaskConfigurationResponse.java
@@ -1,0 +1,7 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration;
+
+import java.time.Duration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskConfigurationResponse;
+
+public record HttpHealthcheckTaskConfigurationResponse(int port, String path, Duration timeout)
+    implements MonitoringTaskConfigurationResponse {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/PingTaskConfigurationResponse.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/PingTaskConfigurationResponse.java
@@ -1,0 +1,7 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration;
+
+import java.time.Duration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskConfigurationResponse;
+
+public record PingTaskConfigurationResponse(Duration timeout)
+    implements MonitoringTaskConfigurationResponse {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/TelnetTaskConfigurationResponse.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/TelnetTaskConfigurationResponse.java
@@ -1,0 +1,7 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration;
+
+import java.time.Duration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskConfigurationResponse;
+
+public record TelnetTaskConfigurationResponse(int port, Duration timeout)
+    implements MonitoringTaskConfigurationResponse {}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/package-info.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/dto/response/configuration/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/mapper/MonitoringTaskMapper.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/mapper/MonitoringTaskMapper.java
@@ -3,10 +3,18 @@ package pl.sgorski.nethelt.webapi.features.monitoring_task.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTask;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskCreateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskUpdateCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.HttpHealthcheckTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.PingTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.TelnetTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskConfigurationRequest;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskCreateRequest;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.MonitoringTaskUpdateRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.HttpHealthcheckTaskConfigurationRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.PingTaskConfigurationRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.TelnetTaskConfigurationRequest;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskResponse;
 
 @Mapper(componentModel = "spring")
@@ -17,4 +25,20 @@ public interface MonitoringTaskMapper {
   MonitoringTaskUpdateCommand toCommand(MonitoringTaskUpdateRequest request);
 
   MonitoringTaskCreateCommand toCommand(MonitoringTaskCreateRequest request);
+
+  PingTaskConfigurationCommand toCommand(PingTaskConfigurationRequest request);
+
+  TelnetTaskConfigurationCommand toCommand(TelnetTaskConfigurationRequest request);
+
+  HttpHealthcheckTaskConfigurationCommand toCommand(
+      HttpHealthcheckTaskConfigurationRequest request);
+
+  default MonitoringTaskConfigurationCommand toCommand(MonitoringTaskConfigurationRequest request) {
+    return switch (request) {
+      case PingTaskConfigurationRequest ping -> toCommand(ping);
+      case TelnetTaskConfigurationRequest telnet -> toCommand(telnet);
+      case HttpHealthcheckTaskConfigurationRequest http -> toCommand(http);
+      default -> throw new IllegalStateException("Unconvertible type: " + request);
+    };
+  }
 }

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/mapper/MonitoringTaskMapper.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/mapper/MonitoringTaskMapper.java
@@ -3,6 +3,10 @@ package pl.sgorski.nethelt.webapi.features.monitoring_task.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTask;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.HttpHealthcheckTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.TelnetTaskConfiguration;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskCreateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskUpdateCommand;
@@ -15,11 +19,16 @@ import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.Monitoring
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.HttpHealthcheckTaskConfigurationRequest;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.PingTaskConfigurationRequest;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.request.configuration.TelnetTaskConfigurationRequest;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskConfigurationResponse;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.MonitoringTaskResponse;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration.HttpHealthcheckTaskConfigurationResponse;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration.PingTaskConfigurationResponse;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.response.configuration.TelnetTaskConfigurationResponse;
 
 @Mapper(componentModel = "spring")
 public interface MonitoringTaskMapper {
   @Mapping(target = "isEnabled", source = "enabled")
+  @Mapping(target = "configuration", source = "configuration")
   MonitoringTaskResponse toResponse(MonitoringTask monitoringTask);
 
   MonitoringTaskUpdateCommand toCommand(MonitoringTaskUpdateRequest request);
@@ -39,6 +48,23 @@ public interface MonitoringTaskMapper {
       case TelnetTaskConfigurationRequest telnet -> toCommand(telnet);
       case HttpHealthcheckTaskConfigurationRequest http -> toCommand(http);
       default -> throw new IllegalStateException("Unconvertible type: " + request);
+    };
+  }
+
+  PingTaskConfigurationResponse toResponse(PingTaskConfiguration configuration);
+
+  TelnetTaskConfigurationResponse toResponse(TelnetTaskConfiguration configuration);
+
+  HttpHealthcheckTaskConfigurationResponse toResponse(
+      HttpHealthcheckTaskConfiguration configuration);
+
+  default MonitoringTaskConfigurationResponse toConfigurationResponse(
+      MonitoringTaskConfiguration configuration) {
+    return switch (configuration) {
+      case PingTaskConfiguration ping -> toResponse(ping);
+      case TelnetTaskConfiguration telnet -> toResponse(telnet);
+      case HttpHealthcheckTaskConfiguration http -> toResponse(http);
+      default -> throw new IllegalStateException("Unconvertible type: " + configuration);
     };
   }
 }

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskConfigurationService.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskConfigurationService.java
@@ -1,0 +1,63 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.service;
+
+import java.time.Duration;
+import org.springframework.stereotype.Service;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.HttpHealthcheckTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.TelnetTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.HttpHealthcheckTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.PingTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.TelnetTaskConfigurationCommand;
+
+@Service
+public class MonitoringTaskConfigurationService {
+
+  public MonitoringTaskConfiguration createConfiguration(
+      TaskType type, MonitoringTaskConfigurationCommand configuration) {
+    return switch (type) {
+      case PING -> createPingTaskConfiguration(configuration);
+      case TELNET -> createTelnetTaskConfiguration(configuration);
+      case HTTP_HEALTHCHECK -> createHttpHealthcheckTaskConfiguration(configuration);
+    };
+  }
+
+  private PingTaskConfiguration createPingTaskConfiguration(
+      MonitoringTaskConfigurationCommand configuration) {
+    if (configuration instanceof PingTaskConfigurationCommand(long timeoutMs)) {
+      var timeout = getDurationFromMillis(timeoutMs);
+      return new PingTaskConfiguration(timeout);
+    }
+    throw new MonitoringTaskValidationFailedException("Invalid configuration for PING task");
+  }
+
+  private TelnetTaskConfiguration createTelnetTaskConfiguration(
+      MonitoringTaskConfigurationCommand configuration) {
+    if (configuration instanceof TelnetTaskConfigurationCommand(int port, long timeoutMs)) {
+      var timeout = getDurationFromMillis(timeoutMs);
+      return new TelnetTaskConfiguration(port, timeout);
+    }
+    throw new MonitoringTaskValidationFailedException("Invalid configuration for TELNET task");
+  }
+
+  private HttpHealthcheckTaskConfiguration createHttpHealthcheckTaskConfiguration(
+      MonitoringTaskConfigurationCommand configuration) {
+    if (configuration
+        instanceof HttpHealthcheckTaskConfigurationCommand(int port, String path, long timeoutMs)) {
+      var timeout = getDurationFromMillis(timeoutMs);
+      return new HttpHealthcheckTaskConfiguration(port, path, timeout);
+    }
+    throw new MonitoringTaskValidationFailedException(
+        "Invalid configuration for HTTP HEALTHCHECK task");
+  }
+
+  private Duration getDurationFromMillis(long millis) {
+    if (millis <= 0) {
+      throw new MonitoringTaskValidationFailedException("Timeout must be greater than 0");
+    }
+    return Duration.ofMillis(millis);
+  }
+}

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskService.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskNotFoundException;
 import pl.sgorski.nethelt.webapi.features.device.service.DeviceService;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTask;
-import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskCreateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskUpdateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.repository.MonitoringTaskRepository;
@@ -18,6 +17,7 @@ import pl.sgorski.nethelt.webapi.features.monitoring_task.repository.MonitoringT
 public class MonitoringTaskService {
 
   private final MonitoringTaskRepository monitoringTaskRepository;
+  private final MonitoringTaskConfigurationService monitoringTaskConfigurationService;
   private final DeviceService deviceService;
 
   public MonitoringTask getMonitoringTask(Long networkId, Long deviceId, Long monitoringTaskId) {
@@ -36,8 +36,9 @@ public class MonitoringTaskService {
   public MonitoringTask createMonitoringTask(
       Long networkId, Long deviceId, MonitoringTaskCreateCommand command) {
     var device = deviceService.getDevice(networkId, deviceId);
-    // todo: replace placeholder with configuration service (a'la factory)
-    var configuration = new PingTaskConfiguration(Duration.ofSeconds(5));
+    var configuration =
+        monitoringTaskConfigurationService.createConfiguration(
+            command.type(), command.configuration());
     var interval = Duration.ofSeconds(command.intervalSeconds());
     var monitoringTask = new MonitoringTask(device, command.type(), interval, configuration);
     return monitoringTaskRepository.save(monitoringTask);
@@ -48,7 +49,10 @@ public class MonitoringTaskService {
       Long networkId, Long deviceId, Long monitoringTaskId, MonitoringTaskUpdateCommand command) {
     var monitoringTask = getMonitoringTask(networkId, deviceId, monitoringTaskId);
     var interval = Duration.ofSeconds(command.intervalSeconds());
-    monitoringTask.update(interval);
+    var configuration =
+        monitoringTaskConfigurationService.createConfiguration(
+            monitoringTask.getType(), command.configuration());
+    monitoringTask.update(interval, configuration);
     return monitoringTask;
   }
 

--- a/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskService.java
+++ b/web-api/src/main/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskNotFoundException;
 import pl.sgorski.nethelt.webapi.features.device.service.DeviceService;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTask;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskCreateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskUpdateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.repository.MonitoringTaskRepository;
@@ -35,8 +36,10 @@ public class MonitoringTaskService {
   public MonitoringTask createMonitoringTask(
       Long networkId, Long deviceId, MonitoringTaskCreateCommand command) {
     var device = deviceService.getDevice(networkId, deviceId);
-    var monitoringTask =
-        new MonitoringTask(device, command.type(), Duration.ofSeconds(command.intervalSeconds()));
+    // todo: replace placeholder with configuration service (a'la factory)
+    var configuration = new PingTaskConfiguration(Duration.ofSeconds(5));
+    var interval = Duration.ofSeconds(command.intervalSeconds());
+    var monitoringTask = new MonitoringTask(device, command.type(), interval, configuration);
     return monitoringTaskRepository.save(monitoringTask);
   }
 
@@ -44,7 +47,8 @@ public class MonitoringTaskService {
   public MonitoringTask updateMonitoringTask(
       Long networkId, Long deviceId, Long monitoringTaskId, MonitoringTaskUpdateCommand command) {
     var monitoringTask = getMonitoringTask(networkId, deviceId, monitoringTaskId);
-    monitoringTask.update(Duration.ofSeconds(command.intervalSeconds()));
+    var interval = Duration.ofSeconds(command.intervalSeconds());
+    monitoringTask.update(interval);
     return monitoringTask;
   }
 

--- a/web-api/src/main/resources/db/migration/V1.5.2__create_monitoring_task_configuration_tables.sql
+++ b/web-api/src/main/resources/db/migration/V1.5.2__create_monitoring_task_configuration_tables.sql
@@ -1,0 +1,26 @@
+CREATE TABLE monitoring_task_configurations (
+    id BIGSERIAL PRIMARY KEY
+);
+
+CREATE TABLE ping_task_configurations (
+    id bigserial PRIMARY KEY,
+    timeout interval NOT NULL,
+    constraint fk_ping_configuration foreign key (id) references monitoring_task_configurations(id) ON DELETE CASCADE
+);
+
+CREATE TABLE telnet_task_configurations (
+    id bigserial PRIMARY KEY,
+    port integer NOT NULL,
+    timeout interval NOT NULL,
+    constraint fk_telnet_configuration foreign key (id) references monitoring_task_configurations(id) ON DELETE CASCADE
+);
+
+CREATE TABLE http_healthcheck_task_configurations (
+    id bigserial PRIMARY KEY,
+    port integer NOT NULL,
+    path varchar(255) NOT NULL,
+    timeout interval NOT NULL,
+    constraint fk_http_healthcheck_configuration foreign key (id) references monitoring_task_configurations(id) ON DELETE CASCADE
+);
+
+ALTER TABLE monitoring_tasks ADD COLUMN configuration_id bigint REFERENCES monitoring_task_configurations(id) ON DELETE CASCADE;

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskTests.java
@@ -26,9 +26,11 @@ public class MonitoringTaskTests {
   @Test
   void update_shouldUpdateInterval() {
     var task = TestMonitoringTaskFactory.createTask(TaskType.PING, Duration.ofMinutes(5));
+    var configuration = new PingTaskConfiguration(Duration.ofSeconds(10));
 
-    task.update(Duration.ofSeconds(30));
+    task.update(Duration.ofSeconds(30), configuration);
 
+    assertSame(configuration, task.getConfiguration());
     assertEquals(Duration.ofSeconds(30), task.getInterval());
   }
 

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/MonitoringTaskTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
 import pl.sgorski.nethelt.webapi.utils.TestDeviceFactory;
 import pl.sgorski.nethelt.webapi.utils.TestMonitoringTaskFactory;
 
@@ -12,9 +13,11 @@ public class MonitoringTaskTests {
   @Test
   void constructor_shouldCreateCorrectObject() {
     var device = TestDeviceFactory.createDevice();
-    var task = new MonitoringTask(device, TaskType.PING, Duration.ofMinutes(5));
+    var configuration = new PingTaskConfiguration(Duration.ofSeconds(5));
+    var task = new MonitoringTask(device, TaskType.PING, Duration.ofMinutes(5), configuration);
 
     assertSame(device, task.getDevice());
+    assertSame(configuration, task.getConfiguration());
     assertEquals(TaskType.PING, task.getType());
     assertEquals(Duration.ofMinutes(5), task.getInterval());
     assertTrue(task.isEnabled());

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfigurationTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/HttpHealthcheckTaskConfigurationTests.java
@@ -1,0 +1,45 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+
+public class HttpHealthcheckTaskConfigurationTests {
+
+  @Test
+  void constructor_shouldCreateValidConfiguration() {
+    var config =
+        new HttpHealthcheckTaskConfiguration(8080, "/health", java.time.Duration.ofSeconds(5));
+
+    assertEquals(8080, config.getPort());
+    assertEquals("/health", config.getPath());
+    assertEquals(Duration.ofSeconds(5), config.getTimeout());
+  }
+
+  @Test
+  void constructor_shouldThrow_whenPortIsNotPositive() {
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> new HttpHealthcheckTaskConfiguration(0, "/health", java.time.Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void constructor_shouldThrow_whenPortIsTooBig() {
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () ->
+            new HttpHealthcheckTaskConfiguration(
+                65536, "/health", java.time.Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void constructor_shouldThrow_whenPathNotStartsWithBackslash() {
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () ->
+            new HttpHealthcheckTaskConfiguration(8080, "health", java.time.Duration.ofSeconds(5)));
+  }
+}

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/PingTaskConfigurationTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/PingTaskConfigurationTests.java
@@ -1,0 +1,16 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class PingTaskConfigurationTests {
+
+  @Test
+  void constructor_shouldCreateValidConfiguration() {
+    var config = new PingTaskConfiguration(Duration.ofSeconds(3));
+
+    assertEquals(Duration.ofSeconds(3), config.getTimeout());
+  }
+}

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/TelnetTaskConfigurationTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/domain/configuration/TelnetTaskConfigurationTests.java
@@ -1,0 +1,33 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+
+public class TelnetTaskConfigurationTests {
+
+  @Test
+  void constructor_shouldCreateValidConfiguration() {
+    var config = new TelnetTaskConfiguration(8080, Duration.ofSeconds(5));
+
+    assertEquals(8080, config.getPort());
+    assertEquals(Duration.ofSeconds(5), config.getTimeout());
+  }
+
+  @Test
+  void constructor_shouldThrow_whenPortIsNotPositive() {
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> new TelnetTaskConfiguration(0, Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void constructor_shouldThrow_whenPortIsTooBig() {
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> new TelnetTaskConfiguration(65536, Duration.ofSeconds(5)));
+  }
+}

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskConfigurationServiceTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskConfigurationServiceTests.java
@@ -1,0 +1,104 @@
+package pl.sgorski.nethelt.webapi.features.monitoring_task.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.HttpHealthcheckTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.TelnetTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.HttpHealthcheckTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.PingTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.TelnetTaskConfigurationCommand;
+
+public class MonitoringTaskConfigurationServiceTests {
+
+  private MonitoringTaskConfigurationService monitoringTaskConfigurationService;
+
+  @BeforeEach
+  void setUp() {
+    monitoringTaskConfigurationService = new MonitoringTaskConfigurationService();
+  }
+
+  @Test
+  void createConfiguration_shouldCreatePingTaskConfiguration() {
+    var type = TaskType.PING;
+    var configCommand = new PingTaskConfigurationCommand(1000L);
+
+    var result = monitoringTaskConfigurationService.createConfiguration(type, configCommand);
+
+    assertInstanceOf(PingTaskConfiguration.class, result);
+    var pingConfig = (PingTaskConfiguration) result;
+    assertEquals(Duration.ofSeconds(1), pingConfig.getTimeout());
+  }
+
+  @Test
+  void createConfiguration_shouldCreateTelnetTaskConfiguration() {
+    var type = TaskType.TELNET;
+    var configCommand = new TelnetTaskConfigurationCommand(8080, 1000L);
+
+    var result = monitoringTaskConfigurationService.createConfiguration(type, configCommand);
+
+    assertInstanceOf(TelnetTaskConfiguration.class, result);
+    var telnetConfig = (TelnetTaskConfiguration) result;
+    assertEquals(Duration.ofSeconds(1), telnetConfig.getTimeout());
+    assertEquals(8080, telnetConfig.getPort());
+  }
+
+  @Test
+  void createConfiguration_shouldCreateHttpHealthcheckTaskConfiguration() {
+    var type = TaskType.HTTP_HEALTHCHECK;
+    var configCommand = new HttpHealthcheckTaskConfigurationCommand(8080, "/health", 1000L);
+
+    var result = monitoringTaskConfigurationService.createConfiguration(type, configCommand);
+
+    assertInstanceOf(HttpHealthcheckTaskConfiguration.class, result);
+    var healthcheckConfig = (HttpHealthcheckTaskConfiguration) result;
+    assertEquals(Duration.ofSeconds(1), healthcheckConfig.getTimeout());
+    assertEquals(8080, healthcheckConfig.getPort());
+    assertEquals("/health", healthcheckConfig.getPath());
+  }
+
+  @Test
+  void createConfiguration_shouldThrow_whenConfigurationNotMatch_Ping() {
+    var type = TaskType.PING;
+    var configCommand = new HttpHealthcheckTaskConfigurationCommand(8080, "/health", 1000L);
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskConfigurationService.createConfiguration(type, configCommand));
+  }
+
+  @Test
+  void createConfiguration_shouldThrow_whenConfigurationNotMatch_Telnet() {
+    var type = TaskType.TELNET;
+    var configCommand = new PingTaskConfigurationCommand(1000L);
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskConfigurationService.createConfiguration(type, configCommand));
+  }
+
+  @Test
+  void createConfiguration_shouldThrow_whenConfigurationNotMatch_HttpHealthcheck() {
+    var type = TaskType.HTTP_HEALTHCHECK;
+    var configCommand = new TelnetTaskConfigurationCommand(8080, 1000L);
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskConfigurationService.createConfiguration(type, configCommand));
+  }
+
+  @Test
+  void createConfiguration_shouldThrow_whenTimeoutIsNotPositive() {
+    var type = TaskType.PING;
+    var configCommand = new PingTaskConfigurationCommand(0);
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskConfigurationService.createConfiguration(type, configCommand));
+  }
+}

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskServiceTests.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/features/monitoring_task/service/MonitoringTaskServiceTests.java
@@ -13,10 +13,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskNotFoundException;
+import pl.sgorski.nethelt.webapi.exception.domain.monitoring_task.MonitoringTaskValidationFailedException;
 import pl.sgorski.nethelt.webapi.features.device.service.DeviceService;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskCreateCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.MonitoringTaskUpdateCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.HttpHealthcheckTaskConfigurationCommand;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.dto.command.configuration.PingTaskConfigurationCommand;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.repository.MonitoringTaskRepository;
 import pl.sgorski.nethelt.webapi.utils.TestDeviceFactory;
 import pl.sgorski.nethelt.webapi.utils.TestMonitoringTaskFactory;
@@ -25,6 +28,7 @@ import pl.sgorski.nethelt.webapi.utils.TestMonitoringTaskFactory;
 public class MonitoringTaskServiceTests {
 
   @Mock private MonitoringTaskRepository monitoringTaskRepository;
+  @Mock private MonitoringTaskConfigurationService monitoringTaskConfigurationService;
   @Mock private DeviceService deviceService;
   @InjectMocks private MonitoringTaskService monitoringTaskService;
 
@@ -71,8 +75,12 @@ public class MonitoringTaskServiceTests {
   @Test
   void createMonitoringTask_shouldCreateMonitoringTask_whenValidCommand() {
     var device = TestDeviceFactory.createDevice();
-    var command = new MonitoringTaskCreateCommand(TaskType.HTTP_HEALTHCHECK, 30L);
+    var configuration = new HttpHealthcheckTaskConfigurationCommand(8080, "/health", 5000L);
+    var command = new MonitoringTaskCreateCommand(TaskType.HTTP_HEALTHCHECK, 30L, configuration);
     when(deviceService.getDevice(1L, 1L)).thenReturn(device);
+    when(monitoringTaskConfigurationService.createConfiguration(
+            command.type(), command.configuration()))
+        .thenReturn(TestMonitoringTaskFactory.createConfiguration(command.type()));
     when(monitoringTaskRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     var result = monitoringTaskService.createMonitoringTask(1L, 1L, command);
@@ -85,12 +93,32 @@ public class MonitoringTaskServiceTests {
   }
 
   @Test
+  void createMonitoringTask_shouldThrow_whenConfigNotValid() {
+    var device = TestDeviceFactory.createDevice();
+    var configuration = new HttpHealthcheckTaskConfigurationCommand(8080, "/health", 5000L);
+    var command = new MonitoringTaskCreateCommand(TaskType.HTTP_HEALTHCHECK, 30L, configuration);
+    when(deviceService.getDevice(1L, 1L)).thenReturn(device);
+    when(monitoringTaskConfigurationService.createConfiguration(
+            command.type(), command.configuration()))
+        .thenThrow(new MonitoringTaskValidationFailedException("Invalid configuration"));
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskService.createMonitoringTask(1L, 1L, command));
+    verify(monitoringTaskRepository, never()).save(any());
+  }
+
+  @Test
   void updateMonitoringTask_shouldUpdateMonitoringTask_whenValidCommand() {
     var device = TestDeviceFactory.createDevice();
     var monitoringTask =
         TestMonitoringTaskFactory.createTask(device, TaskType.PING, Duration.ofSeconds(10));
-    var command = new MonitoringTaskUpdateCommand(45L);
+    var configuration = new PingTaskConfigurationCommand(5000L);
+    var command = new MonitoringTaskUpdateCommand(45L, configuration);
     when(deviceService.getDevice(1L, 1L)).thenReturn(device);
+    when(monitoringTaskConfigurationService.createConfiguration(
+            monitoringTask.getType(), command.configuration()))
+        .thenReturn(TestMonitoringTaskFactory.createConfiguration(monitoringTask.getType()));
     when(monitoringTaskRepository.findByDeviceAndId(device, 1L))
         .thenReturn(Optional.of(monitoringTask));
 
@@ -101,9 +129,29 @@ public class MonitoringTaskServiceTests {
   }
 
   @Test
+  void updateMonitoringTask_shouldThrow_whenConfigNotValid() {
+    var device = TestDeviceFactory.createDevice();
+    var monitoringTask =
+        TestMonitoringTaskFactory.createTask(device, TaskType.PING, Duration.ofSeconds(10));
+    var configuration = new PingTaskConfigurationCommand(-1L);
+    var command = new MonitoringTaskUpdateCommand(45L, configuration);
+    when(deviceService.getDevice(1L, 1L)).thenReturn(device);
+    when(monitoringTaskRepository.findByDeviceAndId(device, 1L))
+        .thenReturn(Optional.of(monitoringTask));
+    when(monitoringTaskConfigurationService.createConfiguration(
+            monitoringTask.getType(), command.configuration()))
+        .thenThrow(new MonitoringTaskValidationFailedException("Invalid configuration"));
+
+    assertThrows(
+        MonitoringTaskValidationFailedException.class,
+        () -> monitoringTaskService.updateMonitoringTask(1L, 1L, 1L, command));
+  }
+
+  @Test
   void updateMonitoringTask_shouldThrowException_whenMonitoringTaskDoesNotExist() {
     var device = TestDeviceFactory.createDevice();
-    var command = new MonitoringTaskUpdateCommand(45L);
+    var configuration = new PingTaskConfigurationCommand(5000L);
+    var command = new MonitoringTaskUpdateCommand(45L, configuration);
     when(deviceService.getDevice(1L, 1L)).thenReturn(device);
     when(monitoringTaskRepository.findByDeviceAndId(device, 1L)).thenReturn(Optional.empty());
 

--- a/web-api/src/test/java/pl/sgorski/nethelt/webapi/utils/TestMonitoringTaskFactory.java
+++ b/web-api/src/test/java/pl/sgorski/nethelt/webapi/utils/TestMonitoringTaskFactory.java
@@ -3,21 +3,42 @@ package pl.sgorski.nethelt.webapi.utils;
 import java.time.Duration;
 import pl.sgorski.nethelt.webapi.features.device.domain.Device;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTask;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.MonitoringTaskConfiguration;
 import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.TaskType;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.HttpHealthcheckTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.PingTaskConfiguration;
+import pl.sgorski.nethelt.webapi.features.monitoring_task.domain.configuration.TelnetTaskConfiguration;
 
 public final class TestMonitoringTaskFactory {
 
   public static MonitoringTask createTask() {
     var device = TestDeviceFactory.createDevice();
-    return createTask(device, TaskType.PING, Duration.ofSeconds(10));
+    var configuration = new PingTaskConfiguration(Duration.ofSeconds(5));
+    return createTask(device, TaskType.PING, Duration.ofSeconds(10), configuration);
   }
 
   public static MonitoringTask createTask(TaskType type, Duration interval) {
     var device = TestDeviceFactory.createDevice();
-    return createTask(device, type, interval);
+    var configuration = createConfiguration(type);
+    return createTask(device, type, interval, configuration);
   }
 
   public static MonitoringTask createTask(Device device, TaskType type, Duration interval) {
-    return new MonitoringTask(device, type, interval);
+    var configuration = createConfiguration(type);
+    return new MonitoringTask(device, type, interval, configuration);
+  }
+
+  public static MonitoringTask createTask(
+      Device device, TaskType type, Duration interval, MonitoringTaskConfiguration configuration) {
+    return new MonitoringTask(device, type, interval, configuration);
+  }
+
+  public static MonitoringTaskConfiguration createConfiguration(TaskType type) {
+    return switch (type) {
+      case PING -> new PingTaskConfiguration(Duration.ofSeconds(2));
+      case TELNET -> new TelnetTaskConfiguration(8080, Duration.ofSeconds(2));
+      case HTTP_HEALTHCHECK ->
+          new HttpHealthcheckTaskConfiguration(8080, "/healthcheck", Duration.ofSeconds(3));
+    };
   }
 }


### PR DESCRIPTION
## Summary

This PR should contain production ready basic configuraiotns for three types of monitoring tasks:
- ping
- telnet
- http healthcheck

Every task should contain timeout parameter, additionaly there shoudl be type specific fields (eg. port, path).

Every configuration should be included in dedicated database table.

Configuration is mandatory and assigned while creating the monitoring task. There should be proper MonitoringTaskConfigurationService or even Factory. It should resolve confiugration from command and validate if every field is correctly assigned for this type of task.